### PR TITLE
Document PTY integration responsibilities in project spec

### DIFF
--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -482,6 +482,11 @@ Exit code: 1
 - Emits resize notifications that are consumed by the native resize helper when Windows-specific buffer adjustments are required.
 - Responsible for reconnect logic and detecting abnormal PTY exits to drive user-facing error handling.
 
+**Cross-platform benefits:**
+- `node-pty` ships with native backends for Windows (ConPTY), macOS, and Linux (forkpty), giving us a consistent API surface.
+- Reduces the amount of platform-specific process code required for the planned macOS and Linux phases.
+- Simplifies future Phase 7/8 work by keeping PTY responsibilities centralized in one module regardless of platform.
+
 #### 8.3 Native Addons (Node.js)
 **Purpose:** Replace Python dependency for terminal resizing
 


### PR DESCRIPTION
## Summary
- document the dedicated PTY management layer and how it interfaces with the terminal managers and native helpers
- update dependency, architecture, and file structure sections to include node-pty and the new PTY responsibilities
- refresh the Phase 4 checklist to cover PTY integration work and clarify the resize helper’s scope

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e39313be508328bd8fcfb9cd094942